### PR TITLE
SermonVideo component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8330,6 +8330,11 @@
         }
       }
     },
+    "load-script": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+    },
     "loader-fs-cache": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.1.tgz",
@@ -11837,6 +11842,23 @@
         "react-lifecycles-compat": "3.0.4"
       }
     },
+    "react-youtube": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/react-youtube/-/react-youtube-7.9.0.tgz",
+      "integrity": "sha512-2+nBF4qP8nStYEILIO1/SylKOCnnJUxuZm+qCeWA0eeZxnWZIIixfAeAqbzblwx5L1n/26ACocy3epm9Glox8w==",
+      "requires": {
+        "fast-deep-equal": "2.0.1",
+        "prop-types": "15.6.2",
+        "youtube-player": "5.5.2"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        }
+      }
+    },
     "reactstrap": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-6.5.0.tgz",
@@ -13170,6 +13192,11 @@
           "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
         }
       }
+    },
+    "sister": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sister/-/sister-3.0.1.tgz",
+      "integrity": "sha512-aG41gNRHRRxPq52MpX4vtm9tapnr6ENmHUx8LMAJWCOplEMwXzh/dp5WIo52Wl8Zlc/VUyHLJ2snX0ck+Nma9g=="
     },
     "sisteransi": {
       "version": "0.1.1",
@@ -15590,6 +15617,31 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+        }
+      }
+    },
+    "youtube-player": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/youtube-player/-/youtube-player-5.5.2.tgz",
+      "integrity": "sha512-ZGtsemSpXnDky2AUYWgxjaopgB+shFHgXVpiJFeNB5nWEugpW1KWYDaHKuLqh2b67r24GtP6HoSW5swvf0fFIQ==",
+      "requires": {
+        "debug": "2.6.9",
+        "load-script": "1.0.0",
+        "sister": "3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "react-dom": "^16.6.1",
     "react-router-dom": "^4.3.1",
     "react-scripts": "2.1.1",
+    "react-youtube": "^7.9.0",
     "reactstrap": "^6.5.0",
     "typeface-roboto": "0.0.54"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import 'typeface-roboto';
 
 import ContactUs from './components/ContactUs';
 import Home from './components/Home';
-import SermonVideo from './components/SermonVideo';
+import Sermons from './components/Sermons';
 import Staff from './components/Staff';
 import paLogo from './assets/pa-logo.png';
 import './styles.css';
@@ -89,7 +89,7 @@ class App extends Component {
                         <Route path="/contact-us" component={ContactUs} />
                         <Route path="/english-class" render={() => 'english class'} />
                         <Route path="/fellowship-groups" render={() => 'fellowship groups'} />
-                        <Route path="/sermons" component={SermonVideo} />
+                        <Route path="/sermons" component={Sermons} />
                         <Route path="/serve" render={() => 'serve'} />
                         <Route path="/soul-food" render={() => 'soul food'} />
                         <Route path="/staff" component={Staff} />

--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import 'typeface-roboto';
 
 import ContactUs from './components/ContactUs';
 import Home from './components/Home';
+import SermonVideo from './components/SermonVideo';
 import Staff from './components/Staff';
 import paLogo from './assets/pa-logo.png';
 import './styles.css';
@@ -25,62 +26,54 @@ class App extends Component {
                     </Navbar.Header>
                     <Navbar.Collapse>
                         <Nav pullRight>
-                            <NavDropdown eventKey={1} title="About Us" id="basic-nav-dropdown">
-                                <MenuItem eventKey={1.1} href="/mission/">
-                                    Mission
+                            <NavDropdown eventKey={1} id="basic-nav-dropdown" noCaret title="Learn">
+                                <MenuItem eventKey={1.1} href="/sermons">
+                                    Sermons
                                 </MenuItem>
-                                <MenuItem eventKey={1.2} href="/faith/">
-                                    Faith
-                                </MenuItem>
-                                <MenuItem eventKey={1.3} href="/sunday-schedule/">
-                                    Sunday Schedule
-                                </MenuItem>
-                                <MenuItem eventKey={1.4} href="/staff/">
-                                    Staff
-                                </MenuItem>
-                            </NavDropdown>
-                            <NavItem eventKey={2} href="/contact-us/">
-                                Contact Us
-                            </NavItem>
-                            <NavDropdown eventKey={3} title="Church Life" id="basic-nav-dropdown">
-                                <MenuItem eventKey={3.1} href="/fellowship-groups">
-                                    Fellowship Groups
-                                </MenuItem>
-                                <MenuItem eventKey={3.3} href="/baptism">
-                                    Baptism
-                                </MenuItem>
-                                <MenuItem eventKey={3.4} href="/bible-study">
-                                    Bible Study
-                                </MenuItem>
-                            </NavDropdown>
-                            <NavDropdown eventKey={4} title="Message" id="basic-nav-dropdown">
-                                <MenuItem eventKey={4.1} href="/sunday-sermon">
-                                    Sunday Sermon
-                                </MenuItem>
-                                <MenuItem eventKey={4.2} href="/sunday-school">
+                                <MenuItem eventKey={1.2} href="/sunday-school">
                                     Sunday School
                                 </MenuItem>
                             </NavDropdown>
-                            <NavDropdown eventKey={5} title="Community Service" id="basic-nav-dropdown">
-                                <MenuItem eventKey={5.1} href="/citizenship-class">
+                            <NavDropdown eventKey={2} id="basic-nav-dropdown" noCaret title="Grow">
+                                <MenuItem eventKey={2.1} href="/fellowship-groups">
+                                    Fellowship Groups
+                                </MenuItem>
+                                <MenuItem eventKey={2.3} href="/baptism">
+                                    Baptism
+                                </MenuItem>
+                                <MenuItem eventKey={2.4} href="/bible-study">
+                                    Bible Study
+                                </MenuItem>
+                            </NavDropdown>
+                            <NavItem eventKey={3} href="/serve">
+                                Serve
+                            </NavItem>
+                            <NavDropdown eventKey={4} id="basic-nav-dropdown" noCaret title="Ministries">
+                                <MenuItem eventKey={4.1} href="/citizenship-class">
                                     Citizenship Class
                                 </MenuItem>
-                                <MenuItem eventKey={5.2} href="/english-class">
+                                <MenuItem eventKey={4.2} href="/english-class">
                                     English Class
                                 </MenuItem>
-                                <MenuItem eventKey={5.3} href="/soul-food">
+                                <MenuItem eventKey={4.3} href="/soul-food">
                                     Soul Food
                                 </MenuItem>
-                                <MenuItem eventKey={5.4} href="/chinese-treatment">
+                                <MenuItem eventKey={4.4} href="/chinese-treatment">
                                     Chinese Treatment
                                 </MenuItem>
                             </NavDropdown>
-                            <NavDropdown eventKey={6} title="English" id="basic-nav-dropdown">
-                                <MenuItem eventKey={6.1} href="/english">
-                                    English
+                            <NavDropdown eventKey={5} id="basic-nav-dropdown" noCaret title="About Us">
+                                <MenuItem eventKey={5.1} href="/values">
+                                    Values
                                 </MenuItem>
-                                <MenuItem eventKey={6.2} href="/chinese">
-                                    Chinese
+                                <MenuItem eventKey={5.3} href="/sunday-schedule">
+                                    Sunday Schedule
+                                </MenuItem>
+                                <MenuItem eventKey={5.4} href="/staff">
+                                    Staff
+                                </MenuItem>
+                                <MenuItem eventKey={5.5} href="/contact-us">
+                                    Contact Us
                                 </MenuItem>
                             </NavDropdown>
                         </Nav>
@@ -89,22 +82,20 @@ class App extends Component {
                 <Router>
                     <div>
                         <Route exact path="/" component={Home} />
-                        <Route path="/mission" render={() => 'mission'} />
-                        <Route path="/faith" render={() => 'faith'} />
-                        <Route path="/sunday-schedule" render={() => 'sunday schedule'} />
-                        <Route path="/staff" component={Staff} />
-                        <Route path="/contact-us" component={ContactUs} />
-                        <Route path="/fellowship-groups" render={() => 'fellowship groups'} />
                         <Route path="/baptism" render={() => 'baptism'} />
                         <Route path="/bible-study" render={() => 'bible study'} />
-                        <Route path="/sunday-sermon" render={() => 'sunday sermon'} />
-                        <Route path="/sunday-school" render={() => 'sunday school'} />
-                        <Route path="/citizenship-class" render={() => 'citizenship class'} />
-                        <Route path="/english-class" render={() => 'english class'} />
-                        <Route path="/soul-food" render={() => 'soul food'} />
                         <Route path="/chinese-treatment" render={() => 'chinese treatment'} />
-                        <Route path="/english" render={() => 'english'} />
-                        <Route path="/chinese" render={() => 'chinese'} />
+                        <Route path="/citizenship-class" render={() => 'citizenship class'} />
+                        <Route path="/contact-us" component={ContactUs} />
+                        <Route path="/english-class" render={() => 'english class'} />
+                        <Route path="/fellowship-groups" render={() => 'fellowship groups'} />
+                        <Route path="/sermons" component={SermonVideo} />
+                        <Route path="/serve" render={() => 'serve'} />
+                        <Route path="/soul-food" render={() => 'soul food'} />
+                        <Route path="/staff" component={Staff} />
+                        <Route path="/sunday-schedule" render={() => 'sunday schedule'} />
+                        <Route path="/sunday-school" render={() => 'sunday school'} />
+                        <Route path="/values" render={() => 'values'} />
                     </div>
                 </Router>
             </div>

--- a/src/components/SermonVideo.js
+++ b/src/components/SermonVideo.js
@@ -1,0 +1,49 @@
+import React, { Component } from 'react';
+import YouTube from 'react-youtube';
+
+class SermonVideo extends Component {
+    renderVideo(id) {
+        if (!id) {
+            return null;
+        }
+
+        return <YouTube className="sermon-video" videoId={id} />;
+    }
+
+    render() {
+        return (
+            <div className="sermons">
+                <div className="sermon-video-container">
+                    <div className="sermon-video-header">全心全意愛你的家</div>
+                    {this.renderVideo('79Du2JiK-JU')}
+                    <div className="sermon-video-description">
+                        <div className="sermon-video-description-title">PROVERBS 31:10-31</div>
+                        <div className="sermon-video-description-verse">
+                            An excellent wife, who can find? For her worth is far above jewels. The heart of her husband
+                            trusts in her, And he will have no lack of gain. She does him good and not evil All the days
+                            of her life. She looks for wool and flax And works with her hands in delight. She is
+                            like merchant ships; She brings her food from afar. She rises also while it is still night
+                            And gives food to her household And portions to her maidens. She considers a field and
+                            buys it; From her earnings she plants a vineyard. She girds herself with strength And
+                            makes her arms strong. She senses that her gain is good; Her lamp does not go out at night.
+                            She stretches out her hands to the distaff, And her hands grasp the spindle. She
+                            extends her hand to the poor, And she stretches out her hands to the needy. She is not
+                            afraid of the snow for her household, For all her household are clothed with scarlet. She
+                            makes coverings for herself; Her clothing is fine linen and purple. Her husband is known in
+                            the gates, When he sits among the elders of the land. She makes linen garments and sells
+                            them, And supplies belts to the tradesmen. Strength and dignity are her clothing, And
+                            she smiles at the future. She opens her mouth in wisdom, And the teaching of kindness
+                            is on her tongue. She looks well to the ways of her household, And does not eat the bread of
+                            idleness. Her children rise up and bless her; Her husband also, and he praises her, saying:
+                            “Many daughters have done nobly, But you excel them all.” Charm is deceitful and beauty is
+                            vain, But a woman who fears the Lord, she shall be praised. Give her the product of her
+                            hands, And let her works praise her in the gates.
+                        </div>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}
+
+export default SermonVideo;

--- a/src/components/SermonVideo.js
+++ b/src/components/SermonVideo.js
@@ -12,33 +12,30 @@ class SermonVideo extends Component {
 
     render() {
         return (
-            <div className="sermons">
-                <div className="sermon-video-container">
-                    <div className="sermon-video-header">全心全意愛你的家</div>
-                    {this.renderVideo('79Du2JiK-JU')}
-                    <div className="sermon-video-description">
-                        <div className="sermon-video-description-title">PROVERBS 31:10-31</div>
-                        <div className="sermon-video-description-verse">
-                            An excellent wife, who can find? For her worth is far above jewels. The heart of her husband
-                            trusts in her, And he will have no lack of gain. She does him good and not evil All the days
-                            of her life. She looks for wool and flax And works with her hands in delight. She is
-                            like merchant ships; She brings her food from afar. She rises also while it is still night
-                            And gives food to her household And portions to her maidens. She considers a field and
-                            buys it; From her earnings she plants a vineyard. She girds herself with strength And
-                            makes her arms strong. She senses that her gain is good; Her lamp does not go out at night.
-                            She stretches out her hands to the distaff, And her hands grasp the spindle. She
-                            extends her hand to the poor, And she stretches out her hands to the needy. She is not
-                            afraid of the snow for her household, For all her household are clothed with scarlet. She
-                            makes coverings for herself; Her clothing is fine linen and purple. Her husband is known in
-                            the gates, When he sits among the elders of the land. She makes linen garments and sells
-                            them, And supplies belts to the tradesmen. Strength and dignity are her clothing, And
-                            she smiles at the future. She opens her mouth in wisdom, And the teaching of kindness
-                            is on her tongue. She looks well to the ways of her household, And does not eat the bread of
-                            idleness. Her children rise up and bless her; Her husband also, and he praises her, saying:
-                            “Many daughters have done nobly, But you excel them all.” Charm is deceitful and beauty is
-                            vain, But a woman who fears the Lord, she shall be praised. Give her the product of her
-                            hands, And let her works praise her in the gates.
-                        </div>
+            <div className="sermon-video-container">
+                <div className="sermon-video-header">全心全意愛你的家</div>
+                {this.renderVideo('79Du2JiK-JU')}
+                <div className="sermon-video-description">
+                    <div className="sermon-video-description-title">PROVERBS 31:10-31</div>
+                    <div className="sermon-video-description-verse">
+                        An excellent wife, who can find? For her worth is far above jewels. The heart of her husband
+                        trusts in her, And he will have no lack of gain. She does him good and not evil All the days of
+                        her life. She looks for wool and flax And works with her hands in delight. She is like merchant
+                        ships; She brings her food from afar. She rises also while it is still night And gives food to
+                        her household And portions to her maidens. She considers a field and buys it; From her earnings
+                        she plants a vineyard. She girds herself with strength And makes her arms strong. She senses
+                        that her gain is good; Her lamp does not go out at night. She stretches out her hands to the
+                        distaff, And her hands grasp the spindle. She extends her hand to the poor, And she stretches
+                        out her hands to the needy. She is not afraid of the snow for her household, For all her
+                        household are clothed with scarlet. She makes coverings for herself; Her clothing is fine linen
+                        and purple. Her husband is known in the gates, When he sits among the elders of the land. She
+                        makes linen garments and sells them, And supplies belts to the tradesmen. Strength and dignity
+                        are her clothing, And she smiles at the future. She opens her mouth in wisdom, And the teaching
+                        of kindness is on her tongue. She looks well to the ways of her household, And does not eat the
+                        bread of idleness. Her children rise up and bless her; Her husband also, and he praises her,
+                        saying: “Many daughters have done nobly, But you excel them all.” Charm is deceitful and beauty
+                        is vain, But a woman who fears the Lord, she shall be praised. Give her the product of her
+                        hands, And let her works praise her in the gates.
                     </div>
                 </div>
             </div>

--- a/src/components/Sermons.js
+++ b/src/components/Sermons.js
@@ -1,0 +1,15 @@
+import React, { Component } from 'react';
+
+import SermonVideo from './SermonVideo';
+
+class Sermons extends Component {
+    render() {
+        return (
+            <div className="sermons">
+                <SermonVideo />
+            </div>
+        );
+    }
+}
+
+export default Sermons;

--- a/src/styles.css
+++ b/src/styles.css
@@ -8,7 +8,8 @@
     height: 100%;
 }
 
-.home {
+.home,
+.sermons {
     display: flex;
     justify-content: center;
     margin-top: 10px;
@@ -91,4 +92,45 @@
 .staff-card-actions {
     display: flex;
     justify-content: center;
+}
+
+.sermon-video-container {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    width: 100%;
+}
+
+.sermon-video-header {
+    font-size: 24px;
+    margin-bottom: 20px;
+    text-align: center;
+}
+
+.sermon-video {
+    height: 360px;
+    width: 640px;
+}
+
+@media (max-width: 575.98px) {
+    .sermon-video {
+        height: 180px;
+        width: 320px;
+    }
+}
+
+.sermon-video-description {
+    margin: 20px;
+    max-width: 1040px;
+}
+
+.sermon-video-description-title {
+    font-size: 18px;
+    margin-bottom: 5px;
+}
+
+.sermon-video-description-verse {
+    font-size: 12px;
+    font-style: italic;
 }


### PR DESCRIPTION
- make sure to `npm install`, i added a new module.
- added `SermonVideo` component, which loads a youtube video with some description around it
- /sermons loads `Sermons` component, which only renders `SermonVideo` for now. will probably show a list of videos on this page and when clicking on one, will open `SermonVideo` component in a popup or something for them to watch.
- reorganized menu
- sorted `Route`s in alphabetical order