### PR TITLE
location map in contact us page

### DIFF
--- a/src/components/ContactUsWrapper.js
+++ b/src/components/ContactUsWrapper.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 
 import ContactUs from './ContactUs';
+import Location from './Location';
 
 class ContactUsWrapper extends Component {
     render() {
@@ -11,6 +12,7 @@ class ContactUsWrapper extends Component {
                     <div className="contact-us-wrapper-subtitle">We'd love to hear from you!</div>
                 </div>
                 <ContactUs />
+                <Location />
             </div>
         );
     }

--- a/src/components/Location.js
+++ b/src/components/Location.js
@@ -1,0 +1,56 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import './location.css';
+
+class Location extends Component {
+    constructor(props) {
+        super(props);
+
+        this.mapUrl =
+            'https://www.google.com/maps/embed/v1/place?q=place_id:ChIJtd9QHLq7j4ARBSjhR9ouPRQ&key=AIzaSyCVmRXWSX44BRAiL91sjYmANELPUNqjWiw';
+    }
+
+    renderAddress() {
+        const { addressClassName } = this.props;
+
+        return (
+            <div className={addressClassName || 'location-address'} onClick={() => window.open(this.mapUrl)}>
+                <div>4000 Middlefield Rd</div>
+                <div>Building I</div>
+                <div>Palo Alto, CA 94303</div>
+            </div>
+        );
+    }
+
+    renderMap() {
+        return (
+            <div className="location-map-container">
+                <iframe allowFullScreen className="location-map" frameBorder="0" src={this.mapUrl} title="map" />
+            </div>
+        );
+    }
+
+    renderTitle() {
+        return <div className="location-title">Come Visit Us @ Cubberley Community Center</div>;
+    }
+
+    render() {
+        const { addressOnly } = this.props;
+
+        return (
+            <div>
+                {addressOnly ? null : this.renderTitle()}
+                {this.renderAddress()}
+                {addressOnly ? null : this.renderMap()}
+            </div>
+        );
+    }
+}
+
+Location.propTypes = {
+    addressOnly: PropTypes.bool,
+    addressClassName: PropTypes.string,
+};
+
+export default Location;

--- a/src/components/location.css
+++ b/src/components/location.css
@@ -1,0 +1,41 @@
+.location-title-block {
+    margin: 40px 0;
+}
+
+.location-title {
+    font-size: 36px;
+    font-weight: 500;
+    margin-top: 60px;
+    text-align: center;
+}
+
+.location-address {
+    font-size: 20px;
+    font-weight: normal;
+    margin-top: 10px;
+    text-align: center;
+}
+
+.location-address:hover {
+    color: var(--cfcc-blue);
+    cursor: pointer;
+}
+
+.location-map-container {
+    display: flex;
+    justify-content: center;
+    margin: 20px 0;
+    width: 100%;
+}
+
+.location-map {
+    border: 0;
+    height: 450px;
+    width: 600px;
+}
+
+@media (max-width: 575.98px) {
+    .location-map {
+        width: 100%;
+    }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -165,8 +165,6 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
-    padding-left: 50px;
-    padding-right: 50px;
     width: 100%;
 }
 


### PR DESCRIPTION
- show address and location map in /contact-us
- added prop for embedding somewhere else by passing in `addressOnly` to show only clickable address text. pass in `addressClassName` to style text differently.